### PR TITLE
Fix TypeError

### DIFF
--- a/ec2tool.py
+++ b/ec2tool.py
@@ -178,7 +178,7 @@ if __name__ == "__main__":
 
     instances = conn.get_all_instances()
 
-    controller, injectors = parse_instances()
+    controller, injectors = parse_instances(instances)
 
     print "found\n {} injectors".format(len(injectors))
 


### PR DESCRIPTION
Fix for:

```
Traceback (most recent call last):
  File "ec2tool.py", line 181, in <module>
    controller, injectors = parse_instances()
TypeError: parse_instances() takes exactly 1 argument (0 given)
```
